### PR TITLE
feat: custom install and build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,9 @@
 This is a simple GitHub Action to deploy a static website to Netlify.
 
 ## Usage
-To use a GitHub action you can just reference it on your Workflow file 
-(for more info check [this article by Github](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/configuring-a-workflow))
 
-> Important: this action will execute `npm i` and `npm run build`. Please open an issue if another command is needed
+To use a GitHub action you can just reference it on your Workflow file
+(for more info check [this article by Github](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/configuring-a-workflow))
 
 ```yml
 name: 'My Workflow'
@@ -21,8 +20,8 @@ jobs:
     steps:
       - uses: jsmrcaga/action-netlify-deploy@v1.1.0
         with:
-        	NETLIFY_AUTH_TOKEN: ${{ secrets.MY_TOKEN_SECRET }}
-        	NETLIFY_DEPLOY_TO_PROD: true
+          NETLIFY_AUTH_TOKEN: ${{ secrets.MY_TOKEN_SECRET }}
+          NETLIFY_DEPLOY_TO_PROD: true
 ```
 
 ### Inputs
@@ -35,12 +34,15 @@ The inputs this action uses are:
 | Name | Required | Default | Description |
 |:----:|:--------:|:-------:|:-----------:|
 | `NETLIFY_AUTH_TOKEN` | `true` | N/A | The token needed to deploy your site ([generate here](https://app.netlify.com/user/applications#personal-access-tokens))|
-| `NETLIFY_SITE_ID` | `true` | N/A | The site to where deploy your site (get it from the API ID on your Site Settings) | 
-| `NETLIFY_DEPLOY_MESSAGE` | `false` | '' | An optional deploy message | 
+| `NETLIFY_SITE_ID` | `true` | N/A | The site to where deploy your site (get it from the API ID on your Site Settings) |
+| `NETLIFY_DEPLOY_MESSAGE` | `false` | '' | An optional deploy message |
 | `build_directory` | `false` | `'build'` | The directory where your files are built |
 | `functions_directory` | `false` | N/A | The (optional) directory where your Netlify functions are stored |
+| `install_command` | `false` | `npm i` | The (optional) command to install dependencies |
+| `build_command` | `false` | `npm run build` | The (optional) command to build static website |
 
 ## Example
+
 ### Deploy to production on release
 
 > You can setup repo secrets to use in your workflows
@@ -68,6 +70,7 @@ jobs:
 ```
 
 ### Preview Deploy on pull request
+
 ```yml
 name: 'Netlify Preview Deploy'
 

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     description: 'Your Netlify site id'
     required: true
     default: ''
-    
+
   NETLIFY_DEPLOY_TO_PROD:
     description: 'Should the site be deployed to production?'
     required: false
@@ -33,6 +33,16 @@ inputs:
     required: false
     default: ''
 
+  install_command:
+    description: 'Command to install dependencies'
+    required: false
+    default: 'npm i'
+
+  build_command:
+    description: 'Command to build static website'
+    required: false
+    default: 'npm run build'
+
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -42,6 +52,8 @@ runs:
     - ${{ inputs.NETLIFY_DEPLOY_TO_PROD }}
     - ${{ inputs.build_directory }}
     - ${{ inputs.functions_directory }}
+    - ${{ inputs.install_command }}
+    - ${{ inputs.build_command }}
 
 branding:
   icon: activity

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,12 +7,14 @@ NETLIFY_SITE_ID=$2
 NETLIFY_DEPLOY_TO_PROD=$3
 BUILD_DIRECTORY=$4
 FUNCTIONS_DIRECTORY=$5
+INSTALL_COMMAND=$6
+BUILD_COMMAND=$7
 
 # Install dependencies
-npm i
+eval ${INSTALL_COMMAND:-"npm i"}
 
 # Build project
-npm run build
+eval ${BUILD_COMMAND:-"npm run build"}
 
 # Export token to use with netlify's cli
 export NETLIFY_SITE_ID=$NETLIFY_SITE_ID


### PR DESCRIPTION
This PR allows running custom commands to:
- install dependencies
- build static website

New inputs:
- `install_command`
- `build_command`

I updated the readme:
- remove comment asking to open issue if another command is needed
- update inputs documentation
(by looking at the diff, it seems my linter auto-fixed tab/spacing issue :thinking: )

Also, it seems that the function_directory feature was not completed.
So, I fixed it too.
