### PR TITLE
fix: do not pass --alias and --prod together

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,9 +26,7 @@ COMMAND="netlify deploy --dir=$BUILD_DIRECTORY --functions=$FUNCTIONS_DIRECTORY 
 if [[ $NETLIFY_DEPLOY_TO_PROD == "true" ]]
 then
 	COMMAND+=" --prod"
-fi
-
-if [[ -n $DEPLOY_ALIAS ]]
+elif [[ -n $DEPLOY_ALIAS ]]
 then
 	COMMAND+=" --alias $DEPLOY_ALIAS"
 fi


### PR DESCRIPTION
I changed my setup to use both `deploy_alias` and `NETLIFY_DEPLOY_TO_PROD` so that I have single step which works both for PR branches and main branch.

```
with:
  deploy_alias: ${{ env.BRANCH_NAME }}
  NETLIFY_DEPLOY_TO_PROD: ${{ env.BRANCH_NAME == 'master' }}
```

Apparently Netlify CLI does not like both combined.

Of course, it's possible to be creative in the workflow YAML but this should just do