### PR TITLE
Install node using nvm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:current-stretch-slim
+FROM node:current-stretch
 
 ADD entrypoint.sh /entrypoint.sh
 ADD action.yml /action.yml

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The inputs this action uses are:
 | `install_command` | `false` | Auto-detected | The (optional) command to install dependencies. Runs `yarn` when `yarn.lock` is found; `npm i` otherwise |
 | `build_command` | `false` | `npm run build` | The (optional) command to build static website |
 | `deploy_alias` | `false` | '' | (Optional) [Deployed site alias](https://cli.netlify.com/commands/deploy) |
+| `node_version` | `false` | '' | (Optional) Node version or other arguments passed to [nvm install](https://github.com/nvm-sh/nvm#usage) |
 
 ## Example
 
@@ -137,6 +138,8 @@ jobs:
 
 ### Selecting node version
 
-By default, the latest node will be installed before buidling the application.
+By default, the latest node will be installed before building the application.
 
-To select a different release, create an `.nvmrc` file with the desired version range.
+Use the `node_version` input to change the desired version. It will be passed to [`nvm install`](https://github.com/nvm-sh/nvm#usage). Valid examples include `16.3.0`, `14`, or `--lts`.
+
+Alternatively, create an `.nvmrc` file with the desired version range in your repository.

--- a/README.md
+++ b/README.md
@@ -134,3 +134,9 @@ jobs:
           state: success
           target_url: https://${{ env.BRANCH_NAME }}--my-site.netlify.app
 ```
+
+### Selecting node version
+
+By default, the latest node will be installed before buidling the application.
+
+To select a different release, create an `.nvmrc` file with the desired version range.

--- a/README.md
+++ b/README.md
@@ -143,3 +143,7 @@ By default, the latest node will be installed before building the application.
 Use the `node_version` input to change the desired version. It will be passed to [`nvm install`](https://github.com/nvm-sh/nvm#usage). Valid examples include `16.3.0`, `14`, or `--lts`.
 
 Alternatively, create an `.nvmrc` file with the desired version range in your repository.
+
+## Contributors
+
+- [tpluscode](https://github.com/tpluscode)

--- a/action.yml
+++ b/action.yml
@@ -42,9 +42,14 @@ inputs:
     description: 'Command to build static website'
     required: false
     default: 'npm run build'
-  
+
   deploy_alias:
     description: 'Deployment Subdomain name'
+    required: false
+    default: ''
+
+  node_version:
+    description: 'Node version or arguments compatible with `nvm install`'
     required: false
     default: ''
 
@@ -60,6 +65,7 @@ runs:
     - ${{ inputs.install_command }}
     - ${{ inputs.build_command }}
     - ${{ inputs.deploy_alias }}
+    - ${{ inputs.node_version }}
 
 branding:
   icon: activity

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 
+# Install netlify globally before NVM to prevent EACCESS issues
 npm i -g netlify-cli
+
+# Save its exec path to run later
+NETLIFY_CLI=$(which netlify)
+
+# Install node from NVM to honor .nvmrc files
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash
+[ -s "$HOME/.nvm/nvm.sh" ] && \. "$HOME/.nvm/nvm.sh"
+
+nvm install
 
 NETLIFY_AUTH_TOKEN=$1
 NETLIFY_SITE_ID=$2
@@ -29,7 +39,7 @@ eval ${BUILD_COMMAND:-"npm run build"}
 export NETLIFY_SITE_ID=$NETLIFY_SITE_ID
 export NETLIFY_AUTH_TOKEN=$NETLIFY_AUTH_TOKEN
 
-COMMAND="netlify deploy --dir=$BUILD_DIRECTORY --functions=$FUNCTIONS_DIRECTORY --message=\"$INPUT_NETLIFY_DEPLOY_MESSAGE\""
+COMMAND="$NETLIFY_CLI deploy --dir=$BUILD_DIRECTORY --functions=$FUNCTIONS_DIRECTORY --message=\"$INPUT_NETLIFY_DEPLOY_MESSAGE\""
 
 if [[ $NETLIFY_DEPLOY_TO_PROD == "true" ]]
 then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ NETLIFY_CLI=$(which netlify)
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash
 [ -s "$HOME/.nvm/nvm.sh" ] && \. "$HOME/.nvm/nvm.sh"
 
-nvm install
+nvm install "$9"
 
 NETLIFY_AUTH_TOKEN=$1
 NETLIFY_SITE_ID=$2


### PR DESCRIPTION
Node 17 broke my webpack build because of changes in OpenSSL

In this PR I added support for `.nvmrc` file so that the right node version will be installed if overridden in the repo.