### PR TITLE
fix: use $GITHUB_OUTPUT instead set-output(deprecated)

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -73,7 +73,19 @@ NETLIFY_PREVIEW_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-
 NETLIFY_LOGS_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://app.netlify.com/[a-zA-Z0-9./?=_-]*') #Unique key: app.netlify.com
 NETLIFY_LIVE_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*' | grep -Eov "netlify.com") #Unique key: don't containr -- and app.netlify.com
 
-echo "::set-output name=NETLIFY_OUTPUT::$NETLIFY_OUTPUT"
-echo "::set-output name=NETLIFY_PREVIEW_URL::$NETLIFY_PREVIEW_URL"
-echo "::set-output name=NETLIFY_LOGS_URL::$NETLIFY_LOGS_URL"
-echo "::set-output name=NETLIFY_LIVE_URL::$NETLIFY_LIVE_URL"
+
+echo "NETLIFY_OUTPUT<<EOF" >> $GITHUB_OUTPUT
+echo "$NETLIFY_OUTPUT" >> $GITHUB_OUTPUT
+echo "EOF" >> $GITHUB_OUTPUT
+
+echo "NETLIFY_PREVIEW_URL<<EOF" >> $GITHUB_OUTPUT
+echo "$NETLIFY_PREVIEW_URL" >> $GITHUB_OUTPUT
+echo "EOF" >> $GITHUB_OUTPUT
+
+echo "NETLIFY_LOGS_URL<<EOF" >> $GITHUB_OUTPUT
+echo "$NETLIFY_LOGS_URL" >> $GITHUB_OUTPUT
+echo "EOF" >> $GITHUB_OUTPUT
+
+echo "NETLIFY_LIVE_URL<<EOF" >> $GITHUB_OUTPUT
+echo "$NETLIFY_LIVE_URL" >> $GITHUB_OUTPUT
+echo "EOF" >> $GITHUB_OUTPUT

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -73,19 +73,7 @@ NETLIFY_PREVIEW_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-
 NETLIFY_LOGS_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://app.netlify.com/[a-zA-Z0-9./?=_-]*') #Unique key: app.netlify.com
 NETLIFY_LIVE_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*' | grep -Eov "netlify.com") #Unique key: don't containr -- and app.netlify.com
 
-
-echo "NETLIFY_OUTPUT<<EOF" >> $GITHUB_OUTPUT
-echo "$NETLIFY_OUTPUT" >> $GITHUB_OUTPUT
-echo "EOF" >> $GITHUB_OUTPUT
-
-echo "NETLIFY_PREVIEW_URL<<EOF" >> $GITHUB_OUTPUT
-echo "$NETLIFY_PREVIEW_URL" >> $GITHUB_OUTPUT
-echo "EOF" >> $GITHUB_OUTPUT
-
-echo "NETLIFY_LOGS_URL<<EOF" >> $GITHUB_OUTPUT
-echo "$NETLIFY_LOGS_URL" >> $GITHUB_OUTPUT
-echo "EOF" >> $GITHUB_OUTPUT
-
-echo "NETLIFY_LIVE_URL<<EOF" >> $GITHUB_OUTPUT
-echo "$NETLIFY_LIVE_URL" >> $GITHUB_OUTPUT
-echo "EOF" >> $GITHUB_OUTPUT
+echo "NETLIFY_OUTPUT=$NETLIFY_OUTPUT" >> $GITHUB_ENV
+echo "NETLIFY_PREVIEW_URL=$NETLIFY_PREVIEW_URL" >> $GITHUB_ENV
+echo "NETLIFY_LOGS_URL=$NETLIFY_LOGS_URL" >> $GITHUB_ENV
+echo "NETLIFY_LIVE_URL=$NETLIFY_LIVE_URL" >> $GITHUB_ENV


### PR DESCRIPTION
In the deployments I noticed that some warnings were appearing due to the `set-output` being deprecated, I made the necessary changes to eliminate the warning!

I hope this is helpful, best regards

**warning image:**
![image](https://user-images.githubusercontent.com/71144997/203860782-fa713d53-b84c-47f2-b281-990cb7393be0.png)

**links**:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
