### PR TITLE
Added the crisperit/action-netlify-deploy docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:current-stretch
+FROM crisperit/action-netlify-deploy
 
 ADD entrypoint.sh /entrypoint.sh
 ADD action.yml /action.yml

--- a/action-base-docker/Dockerfile
+++ b/action-base-docker/Dockerfile
@@ -1,0 +1,8 @@
+FROM williamjackson/netlify-cli
+
+USER root
+
+RUN apk add --update curl
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | /bin/bash -l
+RUN [ -s "$HOME/.nvm/nvm.sh" ] && \. "$HOME/.nvm/nvm.sh"
+

--- a/action-base-docker/build-push-image.sh
+++ b/action-base-docker/build-push-image.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+cd "$(dirname "$0")"
+
+version=${1:-0.1.0}
+
+echo "Building crisperit/action-netlify-deploy:${version} and marking it as latest"
+docker build -t "crisperit/action-netlify-deploy:${version}" -t "crisperit/action-netlify-deploy:latest" .
+
+echo "Pushing newest crisperit/action-netlify-deploy"
+docker push crisperit/action-netlify-deploy:${version}
+docker push crisperit/action-netlify-deploy:latest

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,9 +2,6 @@
 
 set -e
 
-# Install netlify globally before NVM to prevent EACCESS issues
-npm i -g netlify-cli
-
 # Save its exec path to run later
 NETLIFY_CLI=$(which netlify)
 
@@ -17,9 +14,6 @@ USE_NVM=$INPUT_USE_NVM
 # Install node from NVM to honor .nvmrc files
 if [[ $USE_NVM == "true" ]] && ([[ -n $NODE_VERSION ]] || [[ -e ".nvmrc" ]])
 then
-	curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash
-	[ -s "$HOME/.nvm/nvm.sh" ] && \. "$HOME/.nvm/nvm.sh"
-
 	if [[ -n $NODE_VERSION ]]
 	then
 		nvm install "$NODE_VERSION"


### PR DESCRIPTION
@jsmrcaga Here is mine idea for the optimization

I've created and pushed to Docker Hub the image optimized for that action
https://hub.docker.com/repository/docker/crisperit/action-netlify-deploy

(You can even think of installing multiple node versions ahead in this image - and on action runtime just switch node versions instead of installing them)

The Netlify deploy with that action took 33 sec 

Previously it was taking 2 minutes..

Fixes #35 