### PR TITLE
Fix step outputs not found issue

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,17 +42,22 @@ inputs:
 outputs:
   NETLIFY_OUTPUT:
     description: netlify command output
+    value: ${{ steps.deployment.outputs.NETLIFY_OUTPUT }}
   NETLIFY_PREVIEW_URL:
     description: deployment preview URL
+    value: ${{ steps.deployment.outputs.NETLIFY_PREVIEW_URL }}
   NETLIFY_LOGS_URL:
     description: deployment preview logs url
+    value: ${{ steps.deployment.outputs.NETLIFY_LOGS_URL }}
   NETLIFY_LIVE_URL:
     description: deployment URL
+    value: ${{ steps.deployment.outputs.NETLIFY_LIVE_URL }}
 runs:
   using: composite
   steps:
       - run: ${{ github.action_path }}/entrypoint.sh
         shell: bash
+        id: deployment
         env:
           NETLIFY_AUTH_TOKEN: ${{ inputs.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ inputs.NETLIFY_SITE_ID }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,18 +43,18 @@ NETLIFY_PREVIEW_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-
 NETLIFY_LOGS_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://app.netlify.com/[a-zA-Z0-9./?=_-]*') #Unique key: app.netlify.com
 NETLIFY_LIVE_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*' | grep -Eov "netlify.com") #Unique key: don't containr -- and app.netlify.com
 
-echo "NETLIFY_OUTPUT<<EOF" >> $GITHUB_ENV
-echo "$NETLIFY_OUTPUT" >> $GITHUB_ENV
-echo "EOF" >> $GITHUB_ENV
+echo "NETLIFY_OUTPUT<<EOF" >> "$GITHUB_OUTPUT"
+echo "$NETLIFY_OUTPUT" >> "$GITHUB_OUTPUT"
+echo "EOF" >> "$GITHUB_OUTPUT"
 
-echo "NETLIFY_PREVIEW_URL<<EOF" >> $GITHUB_ENV
-echo "$NETLIFY_PREVIEW_URL" >> $GITHUB_ENV
-echo "EOF" >> $GITHUB_ENV
+echo "NETLIFY_PREVIEW_URL<<EOF" >> "$GITHUB_OUTPUT"
+echo "$NETLIFY_PREVIEW_URL" >> "$GITHUB_OUTPUT"
+echo "EOF" >> "$GITHUB_OUTPUT"
 
-echo "NETLIFY_LOGS_URL<<EOF" >> $GITHUB_ENV
-echo "$NETLIFY_LOGS_URL" >> $GITHUB_ENV
-echo "EOF" >> $GITHUB_ENV
+echo "NETLIFY_LOGS_URL<<EOF" >> "$GITHUB_OUTPUT"
+echo "$NETLIFY_LOGS_URL" >> "$GITHUB_OUTPUT"
+echo "EOF" >> "$GITHUB_OUTPUT"
 
-echo "NETLIFY_LIVE_URL<<EOF" >> $GITHUB_ENV
-echo "$NETLIFY_LIVE_URL" >> $GITHUB_ENV
-echo "EOF" >> $GITHUB_ENV
+echo "NETLIFY_LIVE_URL<<EOF" >> "$GITHUB_OUTPUT"
+echo "$NETLIFY_LIVE_URL" >> "$GITHUB_OUTPUT"
+echo "EOF" >> "$GITHUB_OUTPUT"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,12 +36,13 @@ then
 fi
 
 OUTPUT=$(sh -c "$COMMAND")
+URL_REGEX='(http|https)://[a-zA-Z0-9./?=_-]*'
 
 # Set outputs
 NETLIFY_OUTPUT=$(echo "$OUTPUT")
-NETLIFY_PREVIEW_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*(--)[a-zA-Z0-9./?=_-]*') #Unique key: --
-NETLIFY_LOGS_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://app.netlify.com/[a-zA-Z0-9./?=_-]*') #Unique key: app.netlify.com
-NETLIFY_LIVE_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*' | grep -Eov "netlify.com") #Unique key: don't containr -- and app.netlify.com
+NETLIFY_PREVIEW_URL=$(echo "$OUTPUT" | grep -Eo "Unique (draft|deploy) URL: +$URL_REGEX" | grep -Eo $URL_REGEX)
+NETLIFY_LOGS_URL=$(echo "$OUTPUT" | grep -Eo "Build logs: +$URL_REGEX" | grep -Eo $URL_REGEX)
+NETLIFY_LIVE_URL=$(echo "$OUTPUT" | grep -Eo "Website URL: +$URL_REGEX" | grep -Eo $URL_REGEX)
 
 echo "NETLIFY_OUTPUT<<EOF" >> "$GITHUB_OUTPUT"
 echo "$NETLIFY_OUTPUT" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
When I use environment and url, it will say url is invalid with blank.
Then I found I can't really get outputs from action step.

I fixed it by 3 change:
- add value properties for composite action with outputs value from `run`, can ref [docs](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputs-for-composite-actions)
- change parameter from env to outputs
- change regexp pattern to get value more accurate

